### PR TITLE
Remove requirement for MVC

### DIFF
--- a/src/Fickle.WebApi.TestWebService/packages.config
+++ b/src/Fickle.WebApi.TestWebService/packages.config
@@ -3,7 +3,6 @@
   <package id="Antlr" version="3.5.0.2" targetFramework="net45" />
   <package id="bootstrap" version="3.3.0" targetFramework="net45" />
   <package id="jQuery" version="2.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Mvc" version="5.2.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
@@ -12,7 +11,6 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.HelpPage" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="3.2.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Modernizr" version="2.8.3" targetFramework="net45" />

--- a/src/Fickle.WebApi/Fickle.WebApi.csproj
+++ b/src/Fickle.WebApi/Fickle.WebApi.csproj
@@ -32,8 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Platform, Version=1.1.0.197, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Fickle.WebApi/WebApiRuntimeServiceModelReflector.cs
+++ b/src/Fickle.WebApi/WebApiRuntimeServiceModelReflector.cs
@@ -120,7 +120,7 @@ namespace Fickle.WebApi
 				return null;
 			}
 
-			if (typeof(IEnumerable<>).IsAssignableFromIgnoreGenericParameters(type))
+			if (type.ContainsGenericParameters && typeof(IEnumerable<>).IsAssignableFromIgnoreGenericParameters(type))
 			{
 				return GetTypeName(type.GetGenericArguments()[0]) + "[]";
 			}

--- a/src/Fickle.WebApi/WebApiRuntimeServiceModelReflector.cs
+++ b/src/Fickle.WebApi/WebApiRuntimeServiceModelReflector.cs
@@ -130,8 +130,13 @@ namespace Fickle.WebApi
 
 		public override ServiceModel Reflect()
 		{
-			var descriptions = Configuration.Services.GetApiExplorer().ApiDescriptions;
-			
+			var descriptions = Configuration.Services.GetApiExplorer().ApiDescriptions.AsEnumerable();
+
+			if (this.Options.ControllersTypesToIgnore != null)
+			{
+				descriptions = descriptions.Where(x => !this.Options.ControllersTypesToIgnore.Contains(x.ActionDescriptor.ControllerDescriptor.ControllerType));
+			}
+
 			var httpRequestMessage = HttpContext.Current.Items["MS_HttpRequestMessage"] as HttpRequestMessage;
 			var httpRequestContext = httpRequestMessage.Properties[HttpPropertyKeys.RequestContextKey] as HttpRequestContext;
 

--- a/src/Fickle.WebApi/packages.config
+++ b/src/Fickle.WebApi/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
   <package id="Platform.NET" version="1.1.0.197" targetFramework="net45" />
   <package id="Platform.VirtualFileSystem" version="1.1.0.102" targetFramework="net45" />
   <package id="Platform.Xml.Serialization" version="1.1.0.197" targetFramework="net45" />

--- a/src/Fickle/Reflectors/ServiceModelReflectionOptions.cs
+++ b/src/Fickle/Reflectors/ServiceModelReflectionOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Fickle.Reflectors
+﻿using System;
+
+namespace Fickle.Reflectors
 {
 	public class ServiceModelReflectionOptions
 	{
@@ -6,6 +8,7 @@
 		public bool OutputToConsole { get; set; }
 		public string[] Namespaces { get; set; }
 		public string[] ModelAssemblyPaths { get; set; }
-		public string[] GatewayAssebmlyPaths { get; set; }
+		public string[] GatewayAssemblyPaths { get; set; }
+		public Type[] ControllersTypesToIgnore { get; set; }
 	}
 }


### PR DESCRIPTION
Makes FickleController into an ApiController so that projects using Fickle.WebApi don't need to also reference MVC