### PR TITLE
Make Fickle work in non-IIS hosted environments

### DIFF
--- a/src/Fickle.WebApi.TestSelfHost/App.config
+++ b/src/Fickle.WebApi.TestSelfHost/App.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Fickle.WebApi.TestSelfHost/Controllers/FickleController.cs
+++ b/src/Fickle.WebApi.TestSelfHost/Controllers/FickleController.cs
@@ -1,0 +1,44 @@
+﻿using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Web.Http;
+using Fickle.Ficklefile;
+using Fickle.Reflectors;
+
+namespace Fickle.WebApi.TestSelfHost.Controllers
+{
+	public class FickleController
+		: ApiController
+	{
+		[Route("Fickle")]
+		[HttpGet]
+		public HttpResponseMessage Fickle()
+		{
+			var options = new ServiceModelReflectionOptions
+			{
+				ControllersTypesToIgnore = new[] { this.GetType() }
+			};
+
+			var reflector = new WebApiRuntimeServiceModelReflector(options, this.Configuration, this.GetType().Assembly, Request.RequestUri.Host);
+			var serviceModel = reflector.Reflect();
+
+			var content = new PushStreamContent(
+				(stream, httpContent, transportContext) =>
+				{
+					using (var streamWriter = new StreamWriter(stream))
+					{
+						var writer = new FicklefileWriter(streamWriter);
+						writer.Write(serviceModel);
+					}
+				},
+				new MediaTypeHeaderValue("text/fickle"));
+
+			var response = new HttpResponseMessage
+			{
+				Content = content
+			};
+
+			return response;
+		}
+	}
+}

--- a/src/Fickle.WebApi.TestSelfHost/Controllers/TestController.cs
+++ b/src/Fickle.WebApi.TestSelfHost/Controllers/TestController.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Web.Http;
+using Fickle.WebApi.TestSelfHost.ServiceModel;
+
+namespace Fickle.WebApi.TestSelfHost.Controllers
+{
+	public class TestController
+		: ApiController
+	{
+		private readonly Random random = new Random();
+
+		[AcceptVerbs("GET")]
+	    public int AddOne(int x)
+	    {
+		    return x + 1;
+	    }
+
+		[AcceptVerbs("GET", "HEAD")]
+		public Sex? GetUserSex(Guid userId)
+		{
+			return Sex.Female;
+		}
+
+		[AcceptVerbs("GET")]
+		public string GetUserName(Guid? id)
+		{
+			return "Bob";
+		}
+
+		[Authorize]
+		[AcceptVerbs("GET")]
+		public int Random()
+		{
+			return random.Next();
+		}
+
+		[AcceptVerbs("GET")]
+		public User GetUser(Guid? id)
+		{
+			return new User
+			{
+				Id = Guid.NewGuid()
+			};
+		}
+
+		[AcceptVerbs("GET")]
+		public void AddUser(User user)
+		{
+		}
+    }
+}

--- a/src/Fickle.WebApi.TestSelfHost/Controllers/ValuesController.cs
+++ b/src/Fickle.WebApi.TestSelfHost/Controllers/ValuesController.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Web.Http;
+
+namespace Fickle.WebApi.TestSelfHost.Controllers
+{
+	public class ValuesController : ApiController
+	{
+		// GET api/values
+		public IEnumerable<string> Get()
+		{
+			return new string[] { "value1", "value2" };
+		}
+
+		// GET api/values/5
+		public string Get(int id)
+		{
+			return "value";
+		}
+
+		// POST api/values
+		public void Post([FromBody]string value)
+		{
+		}
+
+		// PUT api/values/5
+		public void Put(int id, [FromBody]string value)
+		{
+		}
+
+		// DELETE api/values/5
+		public void Delete(int id)
+		{
+		}
+	}
+}

--- a/src/Fickle.WebApi.TestSelfHost/Fickle.WebApi.TestSelfHost.csproj
+++ b/src/Fickle.WebApi.TestSelfHost/Fickle.WebApi.TestSelfHost.csproj
@@ -1,0 +1,111 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{41512821-B4E3-410E-953B-502FBA4E56A6}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Fickle.WebApi.TestSelfHost</RootNamespace>
+    <AssemblyName>Fickle.WebApi.TestSelfHost</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Owin, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.2.0.2\lib\net45\Microsoft.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.2.0.2\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.2.0.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http.Owin, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Controllers\FickleController.cs" />
+    <Compile Include="ServiceModel\Person.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ServiceModel\Sex.cs" />
+    <Compile Include="Startup.cs" />
+    <Compile Include="Controllers\TestController.cs" />
+    <Compile Include="ServiceModel\User.cs" />
+    <Compile Include="Controllers\ValuesController.cs" />
+    <Compile Include="WebApiConfig.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Fickle.WebApi\Fickle.WebApi.csproj">
+      <Project>{A9600AED-C73A-4F5A-ACAD-6E1D157FD47A}</Project>
+      <Name>Fickle.WebApi</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Fickle\Fickle.csproj">
+      <Project>{AA0ED558-3BF6-4CED-8897-415B4D0C858D}</Project>
+      <Name>Fickle</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Fickle.WebApi.TestSelfHost/Program.cs
+++ b/src/Fickle.WebApi.TestSelfHost/Program.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Microsoft.Owin.Hosting;
+
+namespace Fickle.WebApi.TestSelfHost
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			var url = "http://localhost:4321";
+
+			using (WebApp.Start<Startup>(url))
+			{
+				Console.WriteLine("Listening on {0}", url);
+				Console.ReadLine();
+			}
+		}
+	}
+}

--- a/src/Fickle.WebApi.TestSelfHost/Properties/AssemblyInfo.cs
+++ b/src/Fickle.WebApi.TestSelfHost/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Fickle.WebApi.TestSelfHost")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Fickle.WebApi.TestSelfHost")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("41512821-b4e3-410e-953b-502fba4e56a6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Fickle.WebApi.TestSelfHost/ServiceModel/Person.cs
+++ b/src/Fickle.WebApi.TestSelfHost/ServiceModel/Person.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Fickle.WebApi.TestSelfHost.ServiceModel
+{
+	public class Person
+	{
+		public Guid Id { get; set; }
+		public string Name { get; set; }
+		public Sex? Sex { get; set; }
+	}
+}

--- a/src/Fickle.WebApi.TestSelfHost/ServiceModel/Sex.cs
+++ b/src/Fickle.WebApi.TestSelfHost/ServiceModel/Sex.cs
@@ -1,0 +1,8 @@
+﻿namespace Fickle.WebApi.TestSelfHost.ServiceModel
+{
+	public enum Sex
+	{
+		Male,
+		Female
+	}
+}

--- a/src/Fickle.WebApi.TestSelfHost/ServiceModel/User.cs
+++ b/src/Fickle.WebApi.TestSelfHost/ServiceModel/User.cs
@@ -1,0 +1,8 @@
+﻿namespace Fickle.WebApi.TestSelfHost.ServiceModel
+{
+	public class User
+		: Person
+	{
+		public string PublicKeyToken { get; set; }
+	}
+}

--- a/src/Fickle.WebApi.TestSelfHost/Startup.cs
+++ b/src/Fickle.WebApi.TestSelfHost/Startup.cs
@@ -1,0 +1,20 @@
+﻿using System.Web.Http;
+using Fickle.WebApi.TestSelfHost;
+using Microsoft.Owin;
+using Owin;
+
+[assembly: OwinStartup(typeof(Startup))]
+namespace Fickle.WebApi.TestSelfHost
+{
+	public class Startup
+	{
+		public void Configuration(IAppBuilder app)
+		{
+			var config = new HttpConfiguration();
+
+			WebApiConfig.Register(config);
+
+			app.UseWebApi(config);
+		}
+	}
+}

--- a/src/Fickle.WebApi.TestSelfHost/WebApiConfig.cs
+++ b/src/Fickle.WebApi.TestSelfHost/WebApiConfig.cs
@@ -1,0 +1,21 @@
+﻿using System.Web.Http;
+
+namespace Fickle.WebApi.TestSelfHost
+{
+    public static class WebApiConfig
+    {
+        public static void Register(HttpConfiguration config)
+        {
+            // Web API configuration and services
+
+            // Web API routes
+            config.MapHttpAttributeRoutes();
+
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{action}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+            );
+        }
+    }
+}

--- a/src/Fickle.WebApi.TestSelfHost/packages.config
+++ b/src/Fickle.WebApi.TestSelfHost/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.Owin" version="2.0.2" targetFramework="net451" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="2.0.2" targetFramework="net451" />
+  <package id="Microsoft.Owin.Hosting" version="2.0.2" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
+  <package id="Owin" version="1.0" targetFramework="net451" />
+</packages>

--- a/src/Fickle.WebApi.TestWebService/Areas/Fickle/Controllers/FickleController.cs
+++ b/src/Fickle.WebApi.TestWebService/Areas/Fickle/Controllers/FickleController.cs
@@ -19,7 +19,7 @@ namespace Fickle.WebApi.TestWebService.Areas.Fickle.Controllers
 				ControllersTypesToIgnore = new[] { this.GetType() }
 			};
 
-			var reflector = new WebApiRuntimeServiceModelReflector(options, this.Configuration, this.GetType().Assembly);
+			var reflector = new WebApiRuntimeServiceModelReflector(options, this.Configuration, this.GetType().Assembly, Request.RequestUri.Host);
 			var serviceModel = reflector.Reflect();
 
 			var content = new PushStreamContent(

--- a/src/Fickle.sln
+++ b/src/Fickle.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{7528DF93-EF98-402C-B18F-6C604E5471BF}"
 	ProjectSection(SolutionItems) = preProject
@@ -17,6 +17,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fickle.Tests", "..\tests\Fickle.Tests\Fickle.Tests.csproj", "{B1CCA1D4-80A1-4374-A32D-C3A24FC16C80}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fickle.WebApi", "Fickle.WebApi\Fickle.WebApi.csproj", "{A9600AED-C73A-4F5A-ACAD-6E1D157FD47A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fickle.WebApi.TestSelfHost", "Fickle.WebApi.TestSelfHost\Fickle.WebApi.TestSelfHost.csproj", "{41512821-B4E3-410E-953B-502FBA4E56A6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +46,10 @@ Global
 		{A9600AED-C73A-4F5A-ACAD-6E1D157FD47A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A9600AED-C73A-4F5A-ACAD-6E1D157FD47A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A9600AED-C73A-4F5A-ACAD-6E1D157FD47A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41512821-B4E3-410E-953B-502FBA4E56A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41512821-B4E3-410E-953B-502FBA4E56A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41512821-B4E3-410E-953B-502FBA4E56A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41512821-B4E3-410E-953B-502FBA4E56A6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Makes FickleController into an ApiController so that projects using Fickle.WebApi don't need to also reference MVC