### PR TITLE
Add FickleExclude attribute

### DIFF
--- a/src/Fickle.WebApi/Fickle.WebApi.csproj
+++ b/src/Fickle.WebApi/Fickle.WebApi.csproj
@@ -72,6 +72,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FickleExcludeAttribute.cs" />
     <Compile Include="FickleExcludeControllerAttribute.cs" />
     <Compile Include="FickleIncludeTypeAttribute.cs" />
     <Compile Include="FickleSdkInfoAttribute.cs" />

--- a/src/Fickle.WebApi/FickleExcludeAttribute.cs
+++ b/src/Fickle.WebApi/FickleExcludeAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Fickle.WebApi
+{
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method)]
+	public class FickleExcludeAttribute : Attribute
+	{
+	}
+}

--- a/tests/Fickle.WebApi.Tests.ServiceModel/Controllers/TestController.cs
+++ b/tests/Fickle.WebApi.Tests.ServiceModel/Controllers/TestController.cs
@@ -68,5 +68,11 @@ namespace Fickle.WebApi.Tests.ServiceModel.Controllers
 		public void AddUser(User user)
 		{
 		}
+
+		[FickleExclude]
+		[AcceptVerbs("GET")]
+		public void AddExcluded(Excluded thing)
+		{
+		}
 	}
 }

--- a/tests/Fickle.WebApi.Tests.ServiceModel/Fickle.WebApi.Tests.ServiceModel.csproj
+++ b/tests/Fickle.WebApi.Tests.ServiceModel/Fickle.WebApi.Tests.ServiceModel.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Controllers\TestController.cs" />
     <Compile Include="FickleConfig.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ServiceModel\Excluded.cs" />
     <Compile Include="ServiceModel\Person.cs" />
     <Compile Include="ServiceModel\Sex.cs" />
     <Compile Include="ServiceModel\TestEnums.cs" />

--- a/tests/Fickle.WebApi.Tests.ServiceModel/ServiceModel/Excluded.cs
+++ b/tests/Fickle.WebApi.Tests.ServiceModel/ServiceModel/Excluded.cs
@@ -1,0 +1,7 @@
+﻿namespace Fickle.WebApi.Tests.ServiceModel.ServiceModel
+{
+	public class Excluded
+	{
+		public string Blah { get; set; }
+	}
+}

--- a/tests/Fickle.WebApi.Tests.ServiceModel/ServiceModel/Person.cs
+++ b/tests/Fickle.WebApi.Tests.ServiceModel/ServiceModel/Person.cs
@@ -8,5 +8,11 @@ namespace Fickle.WebApi.Tests.ServiceModel.ServiceModel
 		public string Name { get; set; }
 		public Sex? Sex { get; set; }
 		public Person[] Friends { get; set; }
+
+		[FickleExclude]
+		public string Excluded { get; set; }
+
+		[FickleExclude]
+		public Excluded ShouldNotBeIncluded { get; set; }
 	}
 }


### PR DESCRIPTION
Add FickleExclude attribute to allow excluding of api methods and service model properties in generated fickle files